### PR TITLE
Changes to be able to set higher Baud Rates

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "author": "Nabu Casa",
   "license": "MIT",
   "scripts": {
-    "prepublishOnly": "script/build",
-    "prepare": "script/build"
+    "prepublishOnly": "script/build"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "author": "Nabu Casa",
   "license": "MIT",
   "scripts": {
-    "prepublishOnly": "script/build"
+    "prepublishOnly": "script/build",
+    "prepare": "script/build"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^4.1.0",

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -460,10 +460,10 @@ export class ESPLoader extends EventTarget {
         var readLoopRunner = this._parent ? this._parent : this;
 
         readLoopRunner.stopReadLoop = true;
-        await readLoopRunner._reader!.cancel();
-        await readLoopRunner._reader!.releaseLock();
+        await readLoopRunner._reader?.cancel();
+        readLoopRunner._reader?.releaseLock();
         await readLoopRunner.port.close();
-        
+
         //Reopen Port
         await readLoopRunner.port.open({ baudRate: baud });
 
@@ -473,10 +473,7 @@ export class ESPLoader extends EventTarget {
 
         this.logger.log("Changed baud rate to " + baud);
       } catch (e) {
-        throw (
-          "Unable to change the baud rate to " +
-          baud + "."
-        );
+        throw "Unable to change the baud rate to " + baud + ".";
       }
     }
   }

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -451,12 +451,11 @@ export class ESPLoader extends EventTarget {
     } else {
       this.logger.log("Attempting to change baud rate to " + baud + "...");
       try {
-        //We send 115200 as the old one, otherwise the STUB seems to not work properly after changing the baud rate.
+        // Send 115200 as the old one, otherwise the STUB seems to not work properly after changing the baud rate.
         let buffer = pack("<II", baud, 115200);
         await this.checkCommand(ESP_CHANGE_BAUDRATE, buffer);
 
-        //Since SerialPort does not allow to be reconfigured, we need to close it, and re-open it with the new BaudRate after issuing the Command to Change Baud Rate
-        //We stop the ReadLoop
+        // SerialPort does not allow to be reconfigured while open so we close and re-open
         var readLoopRunner = this._parent ? this._parent : this;
 
         readLoopRunner.stopReadLoop = true;
@@ -464,10 +463,10 @@ export class ESPLoader extends EventTarget {
         readLoopRunner._reader?.releaseLock();
         await readLoopRunner.port.close();
 
-        //Reopen Port
+        // Reopen Port
         await readLoopRunner.port.open({ baudRate: baud });
 
-        //Restart Readloop
+        // Restart Readloop
         readLoopRunner.stopReadLoop = false;
         readLoopRunner.readLoop();
 


### PR DESCRIPTION
Loved you presentation the other day on the livestream and wanted to contribute to try and fix the flashing speed.

The setBaudRate was not working because the SerialPort needs to be reconfigured after sending the CHANGE_BAUDRATE operation.

Since the WebSerial does not allow for the port to be reconfigured, it has first to be closed, and then reopened with the new BaudRate, this means we need to stop the ReadLoop in order to be able to close the Reader, reopen the port and restart the read loop.

With the setBaudrate method working, ESP-web-tools can now call it right after initialisation so that it does not flash at the default speed of 115200 which was causing the slowness.

For instance I was able to use it to change baud rate to 1100000 on an ESP32 board that has a CP210X chip. For some reason I can change baud rate to 2Mbps (2000000) on PlatformIO when flashing, but not with WebSerial.

See screen [capture.](https://we.tl/t-dBtrsF98tP)
On flash.ts in esp-web-tools
`  await esploader.initialize();
    await esploader.setBaudrate(1100000);
`
In ESP-web-tools some changes would be needed to perhaps make the baud rate configurable, or at least set it always to something like 921600 which most if not all USB to Serial controllers can do.

PS: My coding may not be the cleanest but I think at least it depicts what would need to be done to be able to reopen the port.