### PR TITLE
Changes to FlashWriteSize

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -18,7 +18,8 @@ export const flashSizes = {
   "16MB": 0x90,
 };
 
-export const FLASH_WRITE_SIZE = 0x200;
+export const FLASH_WRITE_SIZE = 0x400; //Looking at the latest esptool.py 0x400 is the minumum FLASH_WRITE_SIZE
+export const STUB_FLASH_WRITE_SIZE = 0x4000; //Looking at the latest esptool.py it looks like all STUBS have 0x4000 as flash size
 export const ESP32S2_FLASH_WRITE_SIZE = 0x400;
 export const FLASH_SECTOR_SIZE = 0x1000; // Flash sector size, minimum unit of erase.
 export const ESP_ROM_BAUD = 115200;

--- a/src/const.ts
+++ b/src/const.ts
@@ -18,9 +18,8 @@ export const flashSizes = {
   "16MB": 0x90,
 };
 
-export const FLASH_WRITE_SIZE = 0x400; //Looking at the latest esptool.py 0x400 is the minumum FLASH_WRITE_SIZE
-export const STUB_FLASH_WRITE_SIZE = 0x4000; //Looking at the latest esptool.py it looks like all STUBS have 0x4000 as flash size
-export const ESP32S2_FLASH_WRITE_SIZE = 0x400;
+export const FLASH_WRITE_SIZE = 0x400;
+export const STUB_FLASH_WRITE_SIZE = 0x4000;
 export const FLASH_SECTOR_SIZE = 0x1000; // Flash sector size, minimum unit of erase.
 export const ESP_ROM_BAUD = 115200;
 

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -7,7 +7,6 @@ import {
   DEFAULT_TIMEOUT,
   ERASE_REGION_TIMEOUT_PER_MB,
   ESP32S2_DATAREGVALUE,
-  //ESP32S2_FLASH_WRITE_SIZE,
   ESP32_DATAREGVALUE,
   ESP8266_DATAREGVALUE,
   ESP_CHANGE_BAUDRATE,
@@ -509,7 +508,6 @@ export class ESPLoader extends EventTarget {
    * Get the Flash write size based on the chip
    */
   getFlashWriteSize() {
-    //It looks like all stubs share the same Flash Write size, otherwise it defaults to 0x400
     if (this.IS_STUB) {
       return STUB_FLASH_WRITE_SIZE;
     }

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_TIMEOUT,
   ERASE_REGION_TIMEOUT_PER_MB,
   ESP32S2_DATAREGVALUE,
-  ESP32S2_FLASH_WRITE_SIZE,
+  //ESP32S2_FLASH_WRITE_SIZE,
   ESP32_DATAREGVALUE,
   ESP8266_DATAREGVALUE,
   ESP_CHANGE_BAUDRATE,
@@ -24,6 +24,7 @@ import {
   ESP_SYNC,
   FLASH_SECTOR_SIZE,
   FLASH_WRITE_SIZE,
+  STUB_FLASH_WRITE_SIZE,
   MEM_END_ROM_TIMEOUT,
   ROM_INVALID_RECV_MSG,
   SYNC_PACKET,
@@ -508,8 +509,9 @@ export class ESPLoader extends EventTarget {
    * Get the Flash write size based on the chip
    */
   getFlashWriteSize() {
-    if (this.chipFamily == CHIP_FAMILY_ESP32S2) {
-      return ESP32S2_FLASH_WRITE_SIZE;
+    //It looks like all stubs share the same Flash Write size, otherwise it defaults to 0x400
+    if (this.IS_STUB) {
+      return STUB_FLASH_WRITE_SIZE;
     }
     return FLASH_WRITE_SIZE;
   }


### PR DESCRIPTION
Looking at esptool.py it looks like all STUBS have 0x4000 as a flash write size. Updating this along with getFlashWriteSize to be able to flash faster. A bigger data block means less commands to be sent to the STUB.
Before this change it was flashing in blocks of 0x200.