### PR TITLE
Flash Autodetect and Bootloader patching

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -92,7 +92,8 @@ export const SYNC_PACKET = toByteArray(
   "\x07\x07\x12 UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU"
 );
 export const CHIP_DETECT_MAGIC_REG_ADDR = 0x40001000;
-export const CHIP_FAMILY_ESP8266 = 0x8266; // These values for the families are made up nothing that esptool uses.
+// These values for the families are made up; nothing that esptool uses.
+export const CHIP_FAMILY_ESP8266 = 0x8266;
 export const CHIP_FAMILY_ESP32 = 0x32;
 export const CHIP_FAMILY_ESP32S2 = 0x3252;
 export const CHIP_FAMILY_ESP32S3 = 0x3253;

--- a/src/const.ts
+++ b/src/const.ts
@@ -6,7 +6,7 @@ export interface Logger {
   debug(msg: string, ...args: any[]): void;
 }
 export const baudRates = [921600, 115200, 230400, 460800];
-export const flashSizes = {
+export const FLASH_SIZES = {
   "512KB": 0x00,
   "256KB": 0x10,
   "1MB": 0x20,
@@ -18,10 +18,75 @@ export const flashSizes = {
   "16MB": 0x90,
 };
 
+export const ESP32_FLASH_SIZES = {
+  "1MB": 0x00,
+  "2MB": 0x10,
+  "4MB": 0x20,
+  "8MB": 0x30,
+  "16MB": 0x40,
+};
+
+export const FLASH_MODES = {
+  qio: 0,
+  qout: 1,
+  dio: 2,
+  dout: 3,
+};
+
+export const FLASH_FREQUENCIES = {
+  "40m": 0,
+  "26m": 1,
+  "20m": 2,
+  "80m": 0xf,
+};
+
+export const DETECTED_FLASH_SIZES = {
+  0x12: "256KB",
+  0x13: "512KB",
+  0x14: "1MB",
+  0x15: "2MB",
+  0x16: "4MB",
+  0x17: "8MB",
+  0x18: "16MB",
+  0x19: "32MB",
+  0x1a: "64MB",
+};
+
 export const FLASH_WRITE_SIZE = 0x400;
 export const STUB_FLASH_WRITE_SIZE = 0x4000;
 export const FLASH_SECTOR_SIZE = 0x1000; // Flash sector size, minimum unit of erase.
 export const ESP_ROM_BAUD = 115200;
+export const ESP32_BOOTLOADER_FLASH_OFFSET = 0x1000;
+export const BOOTLOADER_FLASH_OFFSET = 0x0;
+export const ESP_IMAGE_MAGIC = 0xe9;
+
+export const ESP32_SPI_REG_BASE = 0x3ff42000;
+export const ESP32_SPI_USR_OFFS = 0x1c;
+export const ESP32_SPI_USR1_OFFS = 0x20;
+export const ESP32_SPI_USR2_OFFS = 0x24;
+export const ESP32_SPI_MOSI_DLEN_OFFS = 0x28;
+export const ESP32_SPI_MISO_DLEN_OFFS = 0x2c;
+export const ESP32_SPI_W0_OFFS = 0x80;
+
+export const ESP8266_SPI_REG_BASE = 0x60000200;
+export const ESP8266_SPI_USR_OFFS = 0x1c;
+export const ESP8266_SPI_USR1_OFFS = 0x20;
+export const ESP8266_SPI_USR2_OFFS = 0x24;
+export const ESP8266_SPI_MOSI_DLEN_OFFS = -1;
+export const ESP8266_SPI_MISO_DLEN_OFFS = -1;
+export const ESP8266_SPI_W0_OFFS = 0x40;
+
+const UART_DATE_REG_ADDR = 0x60000078;
+
+export interface SpiFlashAddresses {
+  regBase: number;
+  usrOffs: number;
+  usr1Offs: number;
+  usr2Offs: number;
+  mosiDlenOffs: number;
+  misoDlenOffs: number;
+  w0Offs: number;
+}
 
 export const SYNC_PACKET = toByteArray(
   "\x07\x07\x12 UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU"
@@ -85,4 +150,65 @@ export const timeoutPerMb = (secondsPerMb: number, sizeBytes: number) => {
     return DEFAULT_TIMEOUT;
   }
   return result;
+};
+
+export const getSpiFlashAddresses = (
+  chipFamily: ChipFamily
+): SpiFlashAddresses => {
+  switch (chipFamily) {
+    case CHIP_FAMILY_ESP32:
+      return {
+        regBase: ESP32_SPI_REG_BASE,
+        usrOffs: ESP32_SPI_USR_OFFS,
+        usr1Offs: ESP32_SPI_USR1_OFFS,
+        usr2Offs: ESP32_SPI_USR2_OFFS,
+        mosiDlenOffs: ESP32_SPI_MOSI_DLEN_OFFS,
+        misoDlenOffs: ESP32_SPI_MISO_DLEN_OFFS,
+        w0Offs: ESP32_SPI_W0_OFFS,
+      };
+    case CHIP_FAMILY_ESP32S2:
+      return {
+        regBase: ESP32_SPI_REG_BASE,
+        usrOffs: ESP32_SPI_USR_OFFS,
+        usr1Offs: ESP32_SPI_USR1_OFFS,
+        usr2Offs: ESP32_SPI_USR2_OFFS,
+        mosiDlenOffs: ESP32_SPI_MOSI_DLEN_OFFS,
+        misoDlenOffs: ESP32_SPI_MISO_DLEN_OFFS,
+        w0Offs: ESP32_SPI_W0_OFFS,
+      };
+    case CHIP_FAMILY_ESP8266:
+      return {
+        regBase: ESP8266_SPI_REG_BASE,
+        usrOffs: ESP8266_SPI_USR_OFFS,
+        usr1Offs: ESP8266_SPI_USR1_OFFS,
+        usr2Offs: ESP8266_SPI_USR2_OFFS,
+        mosiDlenOffs: ESP8266_SPI_MOSI_DLEN_OFFS,
+        misoDlenOffs: ESP8266_SPI_MISO_DLEN_OFFS,
+        w0Offs: ESP8266_SPI_W0_OFFS,
+      };
+    default:
+      return {
+        regBase: -1,
+        usrOffs: -1,
+        usr1Offs: -1,
+        usr2Offs: -1,
+        mosiDlenOffs: -1,
+        misoDlenOffs: -1,
+        w0Offs: -1,
+      };
+  }
+};
+
+export const getUartDateRegAddress = (chipFamily: ChipFamily): number => {
+  // Additional chips like S3 or C6 have different addresses
+  switch (chipFamily) {
+    case CHIP_FAMILY_ESP32:
+      return UART_DATE_REG_ADDR;
+    case CHIP_FAMILY_ESP32S2:
+      return UART_DATE_REG_ADDR;
+    case CHIP_FAMILY_ESP8266:
+      return UART_DATE_REG_ADDR;
+    default:
+      return -1;
+  }
 };

--- a/src/const.ts
+++ b/src/const.ts
@@ -92,13 +92,33 @@ export const SYNC_PACKET = toByteArray(
   "\x07\x07\x12 UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU"
 );
 export const CHIP_DETECT_MAGIC_REG_ADDR = 0x40001000;
-export const CHIP_FAMILY_ESP8266 = 0x8266;
+export const CHIP_FAMILY_ESP8266 = 0x8266; // These values for the families are made up nothing that esptool uses.
 export const CHIP_FAMILY_ESP32 = 0x32;
 export const CHIP_FAMILY_ESP32S2 = 0x3252;
+export const CHIP_FAMILY_ESP32S3 = 0x3253;
+export const CHIP_FAMILY_ESP32C3 = 0x3223;
+export const CHIP_FAMILY_ESP32C6 = 0x3226;
+export const CHIP_FAMILY_ESP32H2 = 0x3272;
 export type ChipFamily =
   | typeof CHIP_FAMILY_ESP8266
   | typeof CHIP_FAMILY_ESP32
-  | typeof CHIP_FAMILY_ESP32S2;
+  | typeof CHIP_FAMILY_ESP32S2
+  | typeof CHIP_FAMILY_ESP32S3
+  | typeof CHIP_FAMILY_ESP32C3
+  | typeof CHIP_FAMILY_ESP32C6
+  | typeof CHIP_FAMILY_ESP32H2;
+
+export const CHIP_DETECT_MAGIC_VALUES = {
+  0xfff0c101: { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
+  0x00f01d83: { name: "ESP32", family: CHIP_FAMILY_ESP32 },
+  0x000007c6: { name: "ESP32-S2", family: CHIP_FAMILY_ESP32S2 },
+  0x9: { name: "ESP32-S3", family: CHIP_FAMILY_ESP32S3 },
+  0xeb004136: { name: "ESP32-S3(beta2)", family: CHIP_FAMILY_ESP32S3 },
+  0x6921506f: { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },
+  0x1b31506f: { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },
+  0xca26cc22: { name: "ESP32-H2", family: CHIP_FAMILY_ESP32H2 },
+  0x0da1806f: { name: "ESP32-C6(beta)", family: CHIP_FAMILY_ESP32C6 },
+};
 
 export const ESP32_DATAREGVALUE = 0x15122500;
 export const ESP8266_DATAREGVALUE = 0x00062000;

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -980,7 +980,7 @@ export class ESPLoader extends EventTarget {
     let oldSpiUsr = await this.readRegister(SPI_USR_REG);
     let oldSpiUsr2 = await this.readRegister(SPI_USR2_REG);
 
-    var flags = SPI_USR_COMMAND;
+    let flags = SPI_USR_COMMAND;
 
     if (readBits > 0) {
       flags |= SPI_USR_MISO;

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -18,6 +18,7 @@ import {
   ESP_MEM_DATA,
   ESP_MEM_END,
   ESP_READ_REG,
+  ESP_WRITE_REG,
   ESP_SPI_ATTACH,
   ESP_SPI_SET_PARAMS,
   ESP_SYNC,
@@ -37,6 +38,17 @@ import {
   ESP_FLASH_DEFL_BEGIN,
   ESP_FLASH_DEFL_DATA,
   ESP_FLASH_DEFL_END,
+  ESP32_BOOTLOADER_FLASH_OFFSET,
+  BOOTLOADER_FLASH_OFFSET,
+  ESP_IMAGE_MAGIC,
+  FLASH_SIZES,
+  ESP32_FLASH_SIZES,
+  FLASH_FREQUENCIES,
+  FLASH_MODES,
+  getSpiFlashAddresses,
+  SpiFlashAddresses,
+  getUartDateRegAddress,
+  DETECTED_FLASH_SIZES,
 } from "./const";
 import { getStubCode } from "./stubs";
 import { pack, sleep, slipEncode, toHex, unpack } from "./util";
@@ -51,6 +63,7 @@ export class ESPLoader extends EventTarget {
   IS_STUB = false;
   connected = true;
   stopReadLoop = false;
+  flashSize: string | null = null;
 
   __inputBuffer?: number[];
   private _reader?: ReadableStreamDefaultReader<Uint8Array>;
@@ -121,6 +134,7 @@ export class ESPLoader extends EventTarget {
         this.chipName = "ESP8266EX";
       }
     }
+    //this.logger.log("FLASHID");
   }
 
   /**
@@ -562,6 +576,7 @@ export class ESPLoader extends EventTarget {
     offset = 0,
     compress = false
   ) {
+    this.updateImageFlashParams(offset, binaryData);
     let uncompressedFilesize = binaryData.byteLength;
     let compressedFilesize = 0;
 
@@ -768,6 +783,281 @@ export class ESPLoader extends EventTarget {
     await this.checkCommand(ESP_FLASH_DEFL_END, buffer);
   }
 
+  getBootloaderOffset() {
+    if (
+      this.chipFamily == CHIP_FAMILY_ESP32 ||
+      this._parent?.chipFamily == CHIP_FAMILY_ESP32
+    ) {
+      return ESP32_BOOTLOADER_FLASH_OFFSET;
+    }
+    return BOOTLOADER_FLASH_OFFSET;
+  }
+
+  updateImageFlashParams(offset: number, image: ArrayBuffer) {
+    // Modify the flash mode & size bytes if this looks like an executable bootloader image
+    if (image.byteLength < 8) {
+      return image; //# not long enough to be a bootloader image
+    }
+
+    // unpack the (potential) image header
+
+    var header = Array.from(new Uint8Array(image, 0, 4));
+    let headerMagic = header[0];
+    let headerFlashMode = header[2];
+    let heatherFlashSizeFreq = header[3];
+
+    this.logger.debug(
+      `Image header, Magic=${toHex(headerMagic)}, FlashMode=${toHex(
+        headerFlashMode
+      )}, FlashSizeFreq=${toHex(heatherFlashSizeFreq)}`
+    );
+
+    if (offset != this.getBootloaderOffset()) {
+      return image; // not flashing bootloader offset, so don't modify this image
+    }
+
+    // easy check if this is an image: does it start with a magic byte?
+    if (headerMagic != ESP_IMAGE_MAGIC) {
+      this.logger.log(
+        "Warning: Image file at %s doesn't look like an image file, so not changing any flash settings.",
+        toHex(offset, 4)
+      );
+      return image;
+    }
+
+    // make sure this really is an image, and not just data that
+    // starts with esp.ESP_IMAGE_MAGIC (mostly a problem for encrypted
+    // images that happen to start with a magic byte
+
+    // TODO Implement this test from esptool.py
+    /*
+    try:
+        test_image = esp.BOOTLOADER_IMAGE(io.BytesIO(image))
+        test_image.verify()
+    except Exception:
+        print("Warning: Image file at 0x%x is not a valid %s image, so not changing any flash settings." % (address, esp.CHIP_NAME))
+        return image
+    */
+
+    this.logger.log("Image being flashed is a bootloader");
+
+    let flashMode = FLASH_MODES["dio"]; // For now we always select dio, a common value supported by many flash chips and ESP boards
+    let flashFreq = FLASH_FREQUENCIES["40m"]; // For now we always select 40m, a common value supported by many flash chips and ESP boards
+    let flashSize =
+      this.getFlashSizes()[this.flashSize ? this.flashSize : "4MB"]; // If size was autodetected we use it otherwise we default to 4MB
+    let flashParams = pack("BB", flashMode, flashSize + flashFreq);
+    let imageFlashParams = new Uint8Array(image, 2, 2);
+
+    if (
+      flashParams[0] != imageFlashParams[0] ||
+      flashParams[1] != imageFlashParams[1]
+    ) {
+      imageFlashParams[0] = flashParams[0];
+      imageFlashParams[1] = flashParams[1];
+
+      this.logger.log(
+        `Patching Flash parameters header bytes to ${toHex(
+          flashParams[0],
+          2
+        )} ${toHex(flashParams[1], 2)}`
+      );
+    } else {
+      this.logger.log("Flash parameters header did not need patching.");
+    }
+    return image;
+  }
+
+  getFlashSizes() {
+    if (
+      this.chipFamily == CHIP_FAMILY_ESP32 ||
+      this._parent?.chipFamily == CHIP_FAMILY_ESP32
+    ) {
+      return ESP32_FLASH_SIZES;
+    }
+    return FLASH_SIZES;
+  }
+
+  async flashId() {
+    let SPIFLASH_RDID = 0x9f;
+    let result = await this.runSpiFlashCommand(SPIFLASH_RDID, [], 24);
+    return result;
+  }
+
+  getChipFamily() {
+    return this._parent ? this._parent.chipFamily : this.chipFamily;
+  }
+
+  async writeRegister(
+    address: number,
+    value: number,
+    mask = 0xffffffff,
+    delayUs = 0,
+    delayAfterUs = 0
+  ) {
+    let buffer = pack("<IIII", address, value, mask, delayUs);
+    if (delayAfterUs > 0) {
+      // add a dummy write to a date register as an excuse to have a delay
+      buffer.concat(
+        pack(
+          "<IIII",
+          getUartDateRegAddress(this.getChipFamily()),
+          0,
+          0,
+          delayAfterUs
+        )
+      );
+    }
+    await this.checkCommand(ESP_WRITE_REG, buffer);
+  }
+
+  async setDataLengths(
+    spiAddresses: SpiFlashAddresses,
+    mosiBits: number,
+    misoBits: number
+  ) {
+    if (spiAddresses.mosiDlenOffs != -1) {
+      // ESP32/32S2/32C3 has a more sophisticated way to set up "user" commands
+      let SPI_MOSI_DLEN_REG = spiAddresses.regBase + spiAddresses.mosiDlenOffs;
+      let SPI_MISO_DLEN_REG = spiAddresses.regBase + spiAddresses.misoDlenOffs;
+      if (mosiBits > 0) {
+        await this.writeRegister(SPI_MOSI_DLEN_REG, mosiBits - 1);
+      }
+      if (misoBits > 0) {
+        await this.writeRegister(SPI_MISO_DLEN_REG, misoBits - 1);
+      }
+    } else {
+      let SPI_DATA_LEN_REG = spiAddresses.regBase + spiAddresses.usr1Offs;
+      let SPI_MOSI_BITLEN_S = 17;
+      let SPI_MISO_BITLEN_S = 8;
+      let mosiMask = mosiBits == 0 ? 0 : mosiBits - 1;
+      let misoMask = misoBits == 0 ? 0 : misoBits - 1;
+      let value =
+        (misoMask << SPI_MISO_BITLEN_S) | (mosiMask << SPI_MOSI_BITLEN_S);
+      await this.writeRegister(SPI_DATA_LEN_REG, value);
+    }
+  }
+  async waitDone(spiCmdReg: number, spiCmdUsr: number) {
+    for (let i = 0; i < 10; i++) {
+      let cmdValue = await this.readRegister(spiCmdReg);
+      if ((cmdValue & spiCmdUsr) == 0) {
+        return;
+      }
+    }
+    throw Error("SPI command did not complete in time");
+  }
+
+  async runSpiFlashCommand(
+    spiflashCommand: number,
+    data: number[],
+    readBits = 0
+  ) {
+    // Run an arbitrary SPI flash command.
+
+    // This function uses the "USR_COMMAND" functionality in the ESP
+    // SPI hardware, rather than the precanned commands supported by
+    // hardware. So the value of spiflash_command is an actual command
+    // byte, sent over the wire.
+
+    // After writing command byte, writes 'data' to MOSI and then
+    // reads back 'read_bits' of reply on MISO. Result is a number.
+
+    // SPI_USR register flags
+    let SPI_USR_COMMAND = 1 << 31;
+    let SPI_USR_MISO = 1 << 28;
+    let SPI_USR_MOSI = 1 << 27;
+
+    // SPI registers, base address differs ESP32* vs 8266
+    let spiAddresses = getSpiFlashAddresses(this.getChipFamily());
+    let base = spiAddresses.regBase;
+    let SPI_CMD_REG = base + 0x00;
+    let SPI_USR_REG = base + spiAddresses.usrOffs;
+    let SPI_USR2_REG = base + spiAddresses.usr2Offs;
+    let SPI_W0_REG = base + spiAddresses.w0Offs;
+
+    // SPI peripheral "command" bitmasks for SPI_CMD_REG
+    let SPI_CMD_USR = 1 << 18;
+
+    // shift values
+    let SPI_USR2_COMMAND_LEN_SHIFT = 28;
+
+    if (readBits > 32) {
+      throw new Error(
+        "Reading more than 32 bits back from a SPI flash operation is unsupported"
+      );
+    }
+    if (data.length > 64) {
+      throw new Error(
+        "Writing more than 64 bytes of data with one SPI command is unsupported"
+      );
+    }
+
+    let dataBits = data.length * 8;
+    let oldSpiUsr = await this.readRegister(SPI_USR_REG);
+    let oldSpiUsr2 = await this.readRegister(SPI_USR2_REG);
+
+    var flags = SPI_USR_COMMAND;
+
+    if (readBits > 0) {
+      flags |= SPI_USR_MISO;
+    }
+    if (dataBits > 0) {
+      flags |= SPI_USR_MOSI;
+    }
+    flags = flags;
+
+    await this.setDataLengths(spiAddresses, dataBits, readBits);
+
+    await this.writeRegister(SPI_USR_REG, flags);
+    await this.writeRegister(
+      SPI_USR2_REG,
+      (7 << SPI_USR2_COMMAND_LEN_SHIFT) | spiflashCommand
+    );
+    if (dataBits == 0) {
+      await this.writeRegister(SPI_W0_REG, 0); // clear data register before we read it
+    } else {
+      data.concat(new Array(data.length % 4).fill(0x00)); // pad to 32-bit multiple
+
+      let words = unpack("I".repeat(Math.floor(data.length / 4)), data);
+      let nextReg = SPI_W0_REG;
+
+      this.logger.debug(`Words Length: ${words.length}`);
+
+      words.forEach(async (word) => {
+        this.logger.debug(
+          `Writing word ${toHex(word)} to register offset ${toHex(nextReg)}`
+        );
+        await this.writeRegister(nextReg, word);
+        nextReg += 4;
+      });
+    }
+    await this.writeRegister(SPI_CMD_REG, SPI_CMD_USR);
+    await this.waitDone(SPI_CMD_REG, SPI_CMD_USR);
+
+    let status = await this.readRegister(SPI_W0_REG);
+    // restore some SPI controller registers
+    await this.writeRegister(SPI_USR_REG, oldSpiUsr);
+    await this.writeRegister(SPI_USR2_REG, oldSpiUsr2);
+    return status;
+  }
+  async detectFlashSize() {
+    this.logger.log("Detecting Flash Size");
+
+    let flashId = await this.flashId();
+    let manufacturer = flashId & 0xff;
+    let flashIdLowbyte = (flashId >> 16) & 0xff;
+
+    this.logger.debug(`FlashId: ${toHex(flashId)}`);
+    this.logger.log(`Flash Manufacturer: ${manufacturer.toString(16)}`);
+    this.logger.log(
+      `Flash Device: ${((flashId >> 8) & 0xff).toString(
+        16
+      )}${flashIdLowbyte.toString(16)}`
+    );
+
+    this.flashSize = DETECTED_FLASH_SIZES[flashIdLowbyte];
+    this.logger.log(`Auto-detected Flash size: ${this.flashSize}`);
+  }
+
   /**
    * @name getEraseSize
    * Calculate an erase size given a specific size in bytes.
@@ -878,6 +1168,10 @@ export class ESPLoader extends EventTarget {
     }
     this.logger.log("Stub is now running...");
     const espStubLoader = new EspStubLoader(this.port, this.logger, this);
+
+    // Try to autodetect the flash size as soon as the stub is running.
+    await espStubLoader.detectFlashSize();
+
     return espStubLoader;
   }
 

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -1006,13 +1006,13 @@ export class ESPLoader extends EventTarget {
 
       this.logger.debug(`Words Length: ${words.length}`);
 
-      words.forEach(async (word) => {
+      for (const word of words) {
         this.logger.debug(
           `Writing word ${toHex(word)} to register offset ${toHex(nextReg)}`
         );
         await this.writeRegister(nextReg, word);
         nextReg += 4;
-      });
+      };
     }
     await this.writeRegister(SPI_CMD_REG, SPI_CMD_USR);
     await this.waitDone(SPI_CMD_REG, SPI_CMD_USR);

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -856,10 +856,7 @@ export class ESPLoader extends EventTarget {
   }
 
   getFlashSizes() {
-    if (
-      this.chipFamily == CHIP_FAMILY_ESP32 ||
-      this._parent?.chipFamily == CHIP_FAMILY_ESP32
-    ) {
+    if (this.getChipFamily() == CHIP_FAMILY_ESP32 ) {
       return ESP32_FLASH_SIZES;
     }
     return FLASH_SIZES;

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -47,7 +47,7 @@ import {
   getUartDateRegAddress,
   DETECTED_FLASH_SIZES,
   CHIP_DETECT_MAGIC_REG_ADDR,
-  CHIP_DETECT_MAGIC_VALUES
+  CHIP_DETECT_MAGIC_VALUES,
 } from "./const";
 import { getStubCode } from "./stubs";
 import { pack, sleep, slipEncode, toHex, unpack } from "./util";
@@ -116,12 +116,12 @@ export class ESPLoader extends EventTarget {
     }
     this.logger.log(`Chip type ${this.chipName}`);
 
-      // if (this._efuses[0] & (1 << 4) || this._efuses[2] & (1 << 16)) {
-      //   this.chipName = "ESP8285";
-      // } else {
-      //   this.chipName = "ESP8266EX";
-      // }
-    
+    // if (this._efuses[0] & (1 << 4) || this._efuses[2] & (1 << 16)) {
+    //   this.chipName = "ESP8285";
+    // } else {
+    //   this.chipName = "ESP8266EX";
+    // }
+
     //this.logger.log("FLASHID");
   }
 

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -856,7 +856,7 @@ export class ESPLoader extends EventTarget {
   }
 
   getFlashSizes() {
-    if (this.getChipFamily() == CHIP_FAMILY_ESP32 ) {
+    if (this.getChipFamily() == CHIP_FAMILY_ESP32) {
       return ESP32_FLASH_SIZES;
     }
     return FLASH_SIZES;
@@ -1012,7 +1012,7 @@ export class ESPLoader extends EventTarget {
         );
         await this.writeRegister(nextReg, word);
         nextReg += 4;
-      };
+      }
     }
     await this.writeRegister(SPI_CMD_REG, SPI_CMD_USR);
     await this.waitDone(SPI_CMD_REG, SPI_CMD_USR);

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -988,7 +988,6 @@ export class ESPLoader extends EventTarget {
     if (dataBits > 0) {
       flags |= SPI_USR_MOSI;
     }
-    flags = flags;
 
     await this.setDataLengths(spiAddresses, dataBits, readBits);
 


### PR DESCRIPTION
- Added commands to autodetect flash size mimicking what esptool.py does. It is called automatically after the stub is run.

- Added bootloader patching on the fly of the flash parameters in the header bytes of the bootloader. In this iteration Flash Mode is always set to DIO and Flash Frequency to 40m. Flash Size is set to the autodetected value, if any, otherwise 4MB. The code checks for a magic bytes that indicate the image being flashed is a bootloader.

To be added in the future:

1. Being able to pass FlashMode and FlashFrequency to flashData so that defaults DIO and 40m can be overridden. ESP-Web-tools would have to be able to pass these in some sort advanced mode? Otherwise there might be boards that cannot be flashed because those settings must be in the bootloader.

2. Esptool.py does one additional check to make sure the image being flashed is in fact a boot loader, just in case by chance a normal user image starts with the "magic header". This is pretty complex code and according to their comments it is a rare occurrence anyway, only more frequent when flashing encrypted images which eep-web-flasher does not support (yet, maybe ever).