### PR TITLE
Fix chip detection for ESP8266

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -135,16 +135,16 @@ export type ChipFamily =
   | typeof CHIP_FAMILY_ESP32H2;
 
 export const CHIP_DETECT_MAGIC_VALUES = {
-  "0xfff0c101": { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
-  "-0x000f3eff": { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
-  "0x00f01d83": { name: "ESP32", family: CHIP_FAMILY_ESP32 },
-  "0x000007c6": { name: "ESP32-S2", family: CHIP_FAMILY_ESP32S2 },
-  "0x00000009": { name: "ESP32-S3", family: CHIP_FAMILY_ESP32S3 },
-  "0xeb004136": { name: "ESP32-S3(beta2)", family: CHIP_FAMILY_ESP32S3 },
-  "0x6921506f": { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },
-  "0x1b31506f": { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },
-  "0xca26cc22": { name: "ESP32-H2", family: CHIP_FAMILY_ESP32H2 },
-  "0x0da1806f": { name: "ESP32-C6(beta)", family: CHIP_FAMILY_ESP32C6 },
+  0xfff0c101: { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
+  [-999617]: { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
+  0x00f01d83: { name: "ESP32", family: CHIP_FAMILY_ESP32 },
+  0x000007c6: { name: "ESP32-S2", family: CHIP_FAMILY_ESP32S2 },
+  0x00000009: { name: "ESP32-S3", family: CHIP_FAMILY_ESP32S3 },
+  0xeb004136: { name: "ESP32-S3(beta2)", family: CHIP_FAMILY_ESP32S3 },
+  0x6921506f: { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },
+  0x1b31506f: { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },
+  0xca26cc22: { name: "ESP32-H2", family: CHIP_FAMILY_ESP32H2 },
+  0x0da1806f: { name: "ESP32-C6(beta)", family: CHIP_FAMILY_ESP32C6 },
 };
 
 export const ESP32_DATAREGVALUE = 0x15122500;

--- a/src/const.ts
+++ b/src/const.ts
@@ -135,11 +135,10 @@ export type ChipFamily =
   | typeof CHIP_FAMILY_ESP32H2;
 
 export const CHIP_DETECT_MAGIC_VALUES = {
-  0xfff0c101: { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
   [-999617]: { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
   0x00f01d83: { name: "ESP32", family: CHIP_FAMILY_ESP32 },
   0x000007c6: { name: "ESP32-S2", family: CHIP_FAMILY_ESP32S2 },
-  0x00000009: { name: "ESP32-S3", family: CHIP_FAMILY_ESP32S3 },
+  0x9: { name: "ESP32-S3", family: CHIP_FAMILY_ESP32S3 },
   0xeb004136: { name: "ESP32-S3(beta2)", family: CHIP_FAMILY_ESP32S3 },
   0x6921506f: { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },
   0x1b31506f: { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },

--- a/src/const.ts
+++ b/src/const.ts
@@ -135,7 +135,7 @@ export type ChipFamily =
   | typeof CHIP_FAMILY_ESP32H2;
 
 export const CHIP_DETECT_MAGIC_VALUES = {
-  [-999617]: { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
+  [-999167]: { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
   0x00f01d83: { name: "ESP32", family: CHIP_FAMILY_ESP32 },
   0x000007c6: { name: "ESP32-S2", family: CHIP_FAMILY_ESP32S2 },
   0x9: { name: "ESP32-S3", family: CHIP_FAMILY_ESP32S3 },

--- a/src/const.ts
+++ b/src/const.ts
@@ -135,15 +135,16 @@ export type ChipFamily =
   | typeof CHIP_FAMILY_ESP32H2;
 
 export const CHIP_DETECT_MAGIC_VALUES = {
-  0xfff0c101: { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
-  0x00f01d83: { name: "ESP32", family: CHIP_FAMILY_ESP32 },
-  0x000007c6: { name: "ESP32-S2", family: CHIP_FAMILY_ESP32S2 },
-  0x9: { name: "ESP32-S3", family: CHIP_FAMILY_ESP32S3 },
-  0xeb004136: { name: "ESP32-S3(beta2)", family: CHIP_FAMILY_ESP32S3 },
-  0x6921506f: { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },
-  0x1b31506f: { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },
-  0xca26cc22: { name: "ESP32-H2", family: CHIP_FAMILY_ESP32H2 },
-  0x0da1806f: { name: "ESP32-C6(beta)", family: CHIP_FAMILY_ESP32C6 },
+  "0xfff0c101": { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
+  "-0x000f3eff": { name: "ESP8266", family: CHIP_FAMILY_ESP8266 },
+  "0x00f01d83": { name: "ESP32", family: CHIP_FAMILY_ESP32 },
+  "0x000007c6": { name: "ESP32-S2", family: CHIP_FAMILY_ESP32S2 },
+  "0x00000009": { name: "ESP32-S3", family: CHIP_FAMILY_ESP32S3 },
+  "0xeb004136": { name: "ESP32-S3(beta2)", family: CHIP_FAMILY_ESP32S3 },
+  "0x6921506f": { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },
+  "0x1b31506f": { name: "ESP32-C3", family: CHIP_FAMILY_ESP32C3 },
+  "0xca26cc22": { name: "ESP32-H2", family: CHIP_FAMILY_ESP32H2 },
+  "0x0da1806f": { name: "ESP32-C6(beta)", family: CHIP_FAMILY_ESP32C6 },
 };
 
 export const ESP32_DATAREGVALUE = 0x15122500;

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -95,7 +95,7 @@ export class ESPLoader extends EventTarget {
 
     // Determine chip family and name
     let chipMagicValue = await this.readRegister(CHIP_DETECT_MAGIC_REG_ADDR);
-    let chip = CHIP_DETECT_MAGIC_VALUES[toHex(chipMagicValue, 8).toLowerCase()];
+    let chip = CHIP_DETECT_MAGIC_VALUES[chipMagicValue];
     if (chip === undefined) {
       throw new Error(
         `Unknown Chip: Hex: ${toHex(

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -834,8 +834,10 @@ export class ESPLoader extends EventTarget {
 
     this.logger.log("Image being flashed is a bootloader");
 
-    let flashMode = FLASH_MODES["dio"]; // For now we always select dio, a common value supported by many flash chips and ESP boards
-    let flashFreq = FLASH_FREQUENCIES["40m"]; // For now we always select 40m, a common value supported by many flash chips and ESP boards
+    // For now we always select dio, a common value supported by many flash chips and ESP boards
+    let flashMode = FLASH_MODES["dio"];
+    // For now we always select 40m, a common value supported by many flash chips and ESP boards
+    let flashFreq = FLASH_FREQUENCIES["40m"];
     let flashSize = getFlashSizes(this.getChipFamily())[
       this.flashSize ? this.flashSize : "4MB"
     ]; // If size was autodetected we use it otherwise we default to 4MB

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -95,9 +95,14 @@ export class ESPLoader extends EventTarget {
 
     // Determine chip family and name
     let chipMagicValue = await this.readRegister(CHIP_DETECT_MAGIC_REG_ADDR);
-    let chip = CHIP_DETECT_MAGIC_VALUES[chipMagicValue];
+    let chip = CHIP_DETECT_MAGIC_VALUES[toHex(chipMagicValue, 8).toLowerCase()];
     if (chip === undefined) {
-      throw new Error(`Unknown Chip: ${toHex(chipMagicValue)}`);
+      throw new Error(
+        `Unknown Chip: Hex: ${toHex(
+          chipMagicValue,
+          8
+        ).toLowerCase()} Number: ${chipMagicValue}`
+      );
     }
     this.chipName = chip.name;
     this.chipFamily = chip.family;
@@ -830,7 +835,7 @@ export class ESPLoader extends EventTarget {
     this.logger.log("Image being flashed is a bootloader");
 
     let flashMode = FLASH_MODES["dio"]; // For now we always select dio, a common value supported by many flash chips and ESP boards
-    let flashFreq = FLASH_FREQUENCIES["80m"]; // For now we always select 40m, a common value supported by many flash chips and ESP boards
+    let flashFreq = FLASH_FREQUENCIES["40m"]; // For now we always select 40m, a common value supported by many flash chips and ESP boards
     let flashSize = getFlashSizes(this.getChipFamily())[
       this.flashSize ? this.flashSize : "4MB"
     ]; // If size was autodetected we use it otherwise we default to 4MB

--- a/src/util.ts
+++ b/src/util.ts
@@ -100,7 +100,12 @@ export const unpack = (format: string, bytes: number[]) => {
 };
 
 export const toHex = (value: number, size = 2) => {
-  return "0x" + value.toString(16).toUpperCase().padStart(size, "0");
+  let hex = value.toString(16).toUpperCase();
+  if (hex.startsWith("-")) {
+    return "-0x" + hex.substring(1).padStart(size, "0");
+  } else {
+    return "0x" + hex.padStart(size, "0");
+  }
 };
 
 export const sleep = (ms: number) =>


### PR DESCRIPTION
Changed keys of CHIP_DETECT_MAGIC_VALUES to Strings as the new magic value being added is a negative one and cannot be used as a key.