### PR TITLE
Fix disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project is used by the [ESP Web Tools](https://github.com/esphome/esp-web-t
 - Clone this repository.
 - Install dependencies with `npm`
 - Run `script/develop`
+- Open http://localhost:5004/
 
 ## Fork
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "esp-web-flasher",
       "version": "3.2.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esp-web-flasher",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Flash ESP devices using WebSerial",
   "main": "dist/index.js",
   "repository": "https://github.com/nabucasa/ESP-Web-flasher",

--- a/script/develop
+++ b/script/develop
@@ -11,7 +11,7 @@ trap "kill 0" EXIT
 # Run tsc once as rollup expects those files
 npm exec -- tsc || true
 
-npm exec -- serve &
+npm exec -- serve -p 5004 &
 npm exec -- tsc --watch &
 npm exec -- rollup -c --watch &
 wait


### PR DESCRIPTION
- Always fire disconnect event when read loop finishes
- On close, wait till the read loop is finished
- **Breaking change:** Reset but don't close the serial port on closing ESP Web Flasher. It's passed in in the open state, so it's up to the caller to close the port.