### PR TITLE
Fix update function returning a smaller value for totalBytes than written

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -300,9 +300,9 @@ async function clickProgram() {
       const progressBar = progress[file].querySelector("div");
       await espStub.flashData(
         contents,
-        (bytesWritten) => {
+        (bytesWritten, totalBytes) => {
           progressBar.style.width =
-            Math.floor((bytesWritten / contents.byteLength) * 100) + "%";
+            Math.floor((bytesWritten / totalBytes) * 100) + "%";
         },
         offset
       );

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -618,7 +618,7 @@ export class ESPLoader extends EventTarget {
         ? Math.round((block.length * uncompressedFilesize) / compressedFilesize)
         : block.length;
       position += flashWriteSize;
-      updateProgress(written, filesize);
+      updateProgress(written, Math.ceil(filesize / flashWriteSize) * flashWriteSize);
     }
     this.logger.log(
       "Took " + (Date.now() - stamp) + "ms to write " + filesize + " bytes"

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -618,10 +618,7 @@ export class ESPLoader extends EventTarget {
         ? Math.round((block.length * uncompressedFilesize) / compressedFilesize)
         : block.length;
       position += flashWriteSize;
-      updateProgress(
-        written,
-        Math.ceil(filesize / flashWriteSize) * flashWriteSize
-      );
+      updateProgress(Math.min(written, filesize), filesize);
     }
     this.logger.log(
       "Took " + (Date.now() - stamp) + "ms to write " + filesize + " bytes"

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -618,7 +618,10 @@ export class ESPLoader extends EventTarget {
         ? Math.round((block.length * uncompressedFilesize) / compressedFilesize)
         : block.length;
       position += flashWriteSize;
-      updateProgress(written, Math.ceil(filesize / flashWriteSize) * flashWriteSize);
+      updateProgress(
+        written,
+        Math.ceil(filesize / flashWriteSize) * flashWriteSize
+      );
     }
     this.logger.log(
       "Took " + (Date.now() - stamp) + "ms to write " + filesize + " bytes"


### PR DESCRIPTION
It was rounding up to the next block size for written, which resulted in percentages like 500%, so this PR should make the numbers more sensible.