### PR TITLE
Fix progress update

### DIFF
--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -618,7 +618,10 @@ export class ESPLoader extends EventTarget {
         ? Math.round((block.length * uncompressedFilesize) / compressedFilesize)
         : block.length;
       position += flashWriteSize;
-      updateProgress(Math.min(written, filesize), filesize);
+      updateProgress(
+        Math.min(written, uncompressedFilesize),
+        uncompressedFilesize
+      );
     }
     this.logger.log(
       "Took " + (Date.now() - stamp) + "ms to write " + filesize + " bytes"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "suppressImplicitAnyIndexErrors": true
+    "suppressImplicitAnyIndexErrors": true,
+    "importHelpers": true
   },
   "include": ["src/*"]
 }


### PR DESCRIPTION
Progress was reported against the `filesize` variable. This variable is set to the compressed file size if compression is enabled. PR #112 ensures that bytes written no longer exceeded the `filesize` variable, but `bytesWritten` represents the actual bytes written. This caused the last ~30% progress to not be reported because that's when actual bytes written exceeded the compressed file size.